### PR TITLE
Use ImGui::WantCaptureKeyboard for key callbacks

### DIFF
--- a/liblava/app/app.cpp
+++ b/liblava/app/app.cpp
@@ -311,7 +311,7 @@ void app::handle_input() {
 
     input.key.listeners.add([&](key_event::ref event) {
 
-        if (gui.capture_mouse()) {
+        if (gui.capture_keyboard()) {
 
             camera.stop();
             return false;

--- a/liblava/app/gui.cpp
+++ b/liblava/app/gui.cpp
@@ -206,7 +206,7 @@ void gui::setup(GLFWwindow* w, config config) {
         if (activated())
             handle_key_event(to_i32(event.key), event.scancode, to_i32(event.action), to_i32(event.mod));
 
-        return capture_mouse();
+        return capture_keyboard();
     };
 
     on_scroll_event = [&](scroll_event const& event) {
@@ -454,6 +454,11 @@ void gui::destroy() {
 bool gui::capture_mouse() const {
 
     return ImGui::GetIO().WantCaptureMouse;
+}
+
+bool gui::capture_keyboard() const {
+
+    return ImGui::GetIO().WantCaptureKeyboard;
 }
 
 void gui::set_ini_file(fs::path dir) {

--- a/liblava/app/gui.hpp
+++ b/liblava/app/gui.hpp
@@ -69,6 +69,7 @@ struct gui : input_callback {
     draw_func on_draw;
 
     bool capture_mouse() const;
+    bool capture_keyboard() const;
 
     void set_active(bool value = true) { active = value; }
     bool activated() const { return active; }


### PR DESCRIPTION
All the `app` callbacks were using `WantCaptureMouse`, so I added `gui::capture_keyboard` to check for the correct ImGui flag for handling key events.