### PR TITLE
allow setting graphics pipeline subpass

### DIFF
--- a/liblava/block/pipeline.cpp
+++ b/liblava/block/pipeline.cpp
@@ -363,7 +363,7 @@ bool graphics_pipeline::create_internal() {
         .pDynamicState = &dynamic_state,
         .layout = layout->get(),
         .renderPass = render_pass,
-        .subpass = 0,
+        .subpass = to_ui32(subpass),
         .basePipelineHandle = 0,
         .basePipelineIndex = -1,
     };

--- a/liblava/block/pipeline.hpp
+++ b/liblava/block/pipeline.hpp
@@ -145,6 +145,9 @@ struct graphics_pipeline : pipeline {
 
     VkRenderPass get_render_pass() const { return render_pass; }
 
+    index get_subpass() const { return subpass; }
+    void set_subpass(index value) { subpass = value; }
+
     bool create(VkRenderPass pass) {
         
         set(pass);
@@ -210,6 +213,7 @@ private:
     void destroy_internal() override;
 
     VkRenderPass render_pass = 0;
+    index subpass = 0;
 
     VkPipelineVertexInputStateCreateInfo vertex_input_state;
     VkVertexInputBindingDescriptions vertex_input_bindings;


### PR DESCRIPTION
When creating a graphics pipeline, you need to specify the subpass it will be used in.