### PR TITLE
Check before mapping and copying buffer data

### DIFF
--- a/liblava/resource/buffer.cpp
+++ b/liblava/resource/buffer.cpp
@@ -72,19 +72,20 @@ bool buffer::create(device_ptr d, void const* data, size_t size, VkBufferUsageFl
     }
 
     if (!mapped) {
+        if (data) {
+            data_ptr map = nullptr;
+            if(failed(vmaMapMemory(device->alloc(), allocation, (void**)(&map))))
+            {
+                log()->error("map buffer memory");
+                return false;
+            }
 
-        data_ptr map = nullptr;
-        if (failed(vmaMapMemory(device->alloc(), allocation, (void**)(&map)))) {
+            memcpy(map, data, size);
 
-            log()->error("map buffer memory");
-            return false;
+            vmaUnmapMemory(device->alloc(), allocation);
         }
-
-        memcpy(map, data, size);
-
-        vmaUnmapMemory(device->alloc(), allocation);
     }
-    else if (data) {
+    else if (data && allocation_info.pMappedData) {
 
         memcpy(allocation_info.pMappedData, data, size);
 

--- a/liblava/resource/buffer.cpp
+++ b/liblava/resource/buffer.cpp
@@ -72,7 +72,9 @@ bool buffer::create(device_ptr d, void const* data, size_t size, VkBufferUsageFl
     }
 
     if (!mapped) {
+
         if (data) {
+
             data_ptr map = nullptr;
             if (failed(vmaMapMemory(device->alloc(), allocation, (void**)(&map)))) {
                 

--- a/liblava/resource/buffer.cpp
+++ b/liblava/resource/buffer.cpp
@@ -74,8 +74,8 @@ bool buffer::create(device_ptr d, void const* data, size_t size, VkBufferUsageFl
     if (!mapped) {
         if (data) {
             data_ptr map = nullptr;
-            if(failed(vmaMapMemory(device->alloc(), allocation, (void**)(&map))))
-            {
+            if (failed(vmaMapMemory(device->alloc(), allocation, (void**)(&map)))) {
+                
                 log()->error("map buffer memory");
                 return false;
             }


### PR DESCRIPTION
Buffers are not necessarily host-visible (when used e.g. for [NV_raytracing scratch buffers](https://github.com/SaschaWillems/Vulkan/blob/fcb0a2a46a7b5e84c29581756f97e258f904bc4f/examples/nv_ray_tracing_basic/nv_ray_tracing_basic.cpp#L354)) so in that case trying to map the memory results in a validation error.

Another issue is that requesting `VMA_ALLOCATION_CREATE_MAPPED_BIT` with `VMA_MEMORY_USAGE_GPU_ONLY` may or may not return mapped memory (works on most integrated GPUs). The code now checks if the memory actually got mapped before trying to copy data.