### PR TITLE
support for specialization constants

### DIFF
--- a/liblava/base/base.hpp
+++ b/liblava/base/base.hpp
@@ -41,6 +41,7 @@ using VkAttachmentReferences = std::vector<VkAttachmentReference>;
 using VkClearValues = std::vector<VkClearValue>;
 
 using VkPipelineShaderStageCreateInfos = std::vector<VkPipelineShaderStageCreateInfo>;
+using VkSpecializationMapEntries = std::vector<VkSpecializationMapEntry>;
 
 using VkVertexInputBindingDescriptions = std::vector<VkVertexInputBindingDescription>;
 using VkVertexInputAttributeDescriptions = std::vector<VkVertexInputAttributeDescription>;

--- a/liblava/block/pipeline.hpp
+++ b/liblava/block/pipeline.hpp
@@ -93,7 +93,9 @@ struct pipeline : id_obj {
 
         void set_stage(VkShaderStageFlagBits stage) { create_info.stage = stage; }
 
-        bool create(device_ptr device, data const& data);
+        void add_specialization_entry(VkSpecializationMapEntry const& specialization);
+
+        bool create(device_ptr device, data const& shader_data, data const& specialization_data = data());
         void destroy();
 
         VkPipelineShaderStageCreateInfo const& get_create_info() const { return create_info; }
@@ -102,6 +104,10 @@ struct pipeline : id_obj {
         device_ptr device = nullptr;
 
         VkPipelineShaderStageCreateInfo create_info;
+        VkSpecializationInfo specialization_info;
+
+        VkSpecializationMapEntries specialization_entries;
+        data specialization_data_copy;
     };
 
 protected:


### PR DESCRIPTION
I don't know how many people use this but I found it pretty useful if you want to work with a 'bindless' approach where you just stuff all your textures into one big sampler array:

```glsl
layout (constant_id = 12) const uint NUM_TEXTURES = 1;

layout (binding = 0) uniform sampler2D textures[NUM_TEXTURES];
```

Without specialization constants (or VK_EXT_descriptor_indexing) you'd have to pick a large number up front, deal with glslang limits and fill the rest of the array with fake descriptors.

At pipeline creation you can now do this:
```c++
uint32_t texture_sampler_count = scene.material_textures.size();

pipeline::shader_stage::ptr stage = make_pipeline_shader_stage(VK_SHADER_STAGE_FRAGMENT_BIT);
stage->add_specialization_entry({
    .constantID = 12,
    .offset = 0,
    .size = sizeof(texture_sampler_count)
});
stage->create(app.device,
              data(frag.spirv.data(), frag.spirv.size() * sizeof(uint32_t)),
              data(&texture_sampler_count, sizeof(texture_sampler_count)));
my_pipeline->add(stage);
```