### PR TITLE
CMake install + find_package support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,7 @@ script:
   - echo ${CXX}
   - ${CXX} --version
   - ${CXX} -v
+  - INSTALL_DIR="${TRAVIS_BUILD_DIR}/install"
   - mkdir -p build && cd build
-  - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release .. && make -j4
+  - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .. && make -j4
+  - make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,17 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         find_package(Threads)
 endif()
 
-add_library(lava.core INTERFACE)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp "")
+
+add_library(lava.core STATIC
+        ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp
+        ${LIBLAVA_DIR}/core/data.hpp
+        ${LIBLAVA_DIR}/core/id.hpp
+        ${LIBLAVA_DIR}/core/math.hpp
+        ${LIBLAVA_DIR}/core/time.hpp
+        ${LIBLAVA_DIR}/core/types.hpp
+        ${LIBLAVA_DIR}/core/version.hpp
+        )
 
 target_include_directories(lava.core INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -61,6 +71,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
                 )
 endif()
 
+set_property(TARGET lava.core PROPERTY EXPORT_NAME core)
 add_library(lava::core ALIAS lava.core)
 
 message(">> lava::util")
@@ -111,6 +122,7 @@ target_link_libraries(lava.util
         spdlog
         )
 
+set_property(TARGET lava.util PROPERTY EXPORT_NAME util)
 add_library(lava::util ALIAS lava.util)
 
 message(">> lava::base")
@@ -141,6 +153,7 @@ target_link_libraries(lava.base
         ${CMAKE_DL_LIBS}
         )
 
+set_property(TARGET lava.base PROPERTY EXPORT_NAME base)
 add_library(lava::base ALIAS lava.base)
 
 message(">> lava::resource")
@@ -176,6 +189,7 @@ target_link_libraries(lava.resource
         lava::base
         )
 
+set_property(TARGET lava.resource PROPERTY EXPORT_NAME resource)
 add_library(lava::resource ALIAS lava.resource)
 
 message(">> lava::frame")
@@ -216,6 +230,7 @@ target_link_libraries(lava.frame
         ${GLFW_LIBRARIES}
         )
 
+set_property(TARGET lava.frame PROPERTY EXPORT_NAME frame)
 add_library(lava::frame ALIAS lava.frame)
 
 message(">> lava::block")
@@ -238,6 +253,7 @@ target_link_libraries(lava.block
         lava::base
         )
 
+set_property(TARGET lava.block PROPERTY EXPORT_NAME block)
 add_library(lava::block ALIAS lava.block)
 
 message(">> lava::app")
@@ -267,6 +283,7 @@ target_link_libraries(lava.app
         lava::block
         )
 
+set_property(TARGET lava.app PROPERTY EXPORT_NAME app)
 add_library(lava::app ALIAS lava.app)
 
 option(LAVA_TESTS "Enable Tests" TRUE)
@@ -347,6 +364,7 @@ configure_package_config_file(
 
 install(EXPORT LavaTargets
         DESTINATION ${CONFIG_PATH}
+        NAMESPACE lava::
         FILE LavaTargets.cmake
         EXPORT_LINK_INTERFACE_LIBRARIES
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,6 @@ install(TARGETS
         EXPORT LavaTargets
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
-        CONFIGURATIONS Debug Release
         INCLUDES DESTINATION include include/liblava/ext
         )
 
@@ -328,7 +327,7 @@ install(DIRECTORY
         ${LIBLAVA_EXT_DIR}/argh/
         ${LIBLAVA_EXT_DIR}/imgui/
         DESTINATION include/liblava/ext
-        FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h" PATTERN "*.inl"
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.inl"
         )
 
 set(CONFIG_PATH lib/cmake/lava)
@@ -349,7 +348,6 @@ configure_package_config_file(
 install(EXPORT LavaTargets
         DESTINATION ${CONFIG_PATH}
         FILE LavaTargets.cmake
-        CONFIGURATIONS Debug Release
         EXPORT_LINK_INTERFACE_LIBRARIES
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,20 +287,6 @@ if(LAVA_TESTS)
                 )
 endif()
 
-set(CONFIG_PATH lib/cmake/lava)
-
-include(CMakePackageConfigHelpers)
-
-write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfigVersion.cmake"
-        COMPATIBILITY AnyNewerVersion
-        )
-
-configure_package_config_file(
-        cmake/LavaConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfig.cmake"
-        INSTALL_DESTINATION ${CONFIG_PATH}
-        )
-
 install(TARGETS
         lava.core
         lava.util
@@ -345,6 +331,21 @@ install(DIRECTORY
         FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h" PATTERN "*.inl"
         )
 
+set(CONFIG_PATH lib/cmake/lava)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfigVersion.cmake"
+        COMPATIBILITY AnyNewerVersion
+        )
+
+configure_package_config_file(
+        cmake/LavaConfig.cmake.in
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfig.cmake"
+        INSTALL_DESTINATION ${CONFIG_PATH}
+        )
+
 install(EXPORT LavaTargets
         DESTINATION ${CONFIG_PATH}
         FILE LavaTargets.cmake
@@ -354,8 +355,8 @@ install(EXPORT LavaTargets
 
 install(
         FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfigVersion.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfig.cmake"
         DESTINATION ${CONFIG_PATH}
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,23 +40,14 @@ set(LIBLAVA_TESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 message(">> lava::core")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-        find_package (Threads)
+        find_package(Threads)
 endif()
 
 add_library(lava.core INTERFACE)
 
 target_include_directories(lava.core INTERFACE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${LIBLAVA_EXT_DIR}/glm
-        )
-
-target_sources(lava.core INTERFACE
-        ${LIBLAVA_DIR}/core/data.hpp
-        ${LIBLAVA_DIR}/core/id.hpp
-        ${LIBLAVA_DIR}/core/math.hpp
-        ${LIBLAVA_DIR}/core/time.hpp
-        ${LIBLAVA_DIR}/core/types.hpp
-        ${LIBLAVA_DIR}/core/version.hpp
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/glm>
         )
 
 target_compile_features(lava.core INTERFACE 
@@ -85,9 +76,8 @@ add_library(lava.util STATIC
         )
 
 target_include_directories(lava.util PUBLIC
-        ${LIBLAVA_EXT_DIR}/spdlog/include
-        ${LIBLAVA_EXT_DIR}/physfs/src
-        ${LIBLAVA_EXT_DIR}/json/single_include
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/physfs/src>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/json/single_include>
         )
 
 message(">>> physfs")
@@ -109,9 +99,16 @@ add_subdirectory(${LIBLAVA_EXT_DIR}/physfs physfs EXCLUDE_FROM_ALL)
 
 message("<<< physfs")
 
+message(">>> spdlog")
+
+add_subdirectory(${LIBLAVA_EXT_DIR}/spdlog spdlog EXCLUDE_FROM_ALL)
+
+message("<<< spdlog")
+
 target_link_libraries(lava.util
         lava::core
         physfs-static
+        spdlog
         )
 
 add_library(lava::util ALIAS lava.util)
@@ -134,9 +131,9 @@ add_library(lava.base STATIC
         )
 
 target_include_directories(lava.base PUBLIC
-        ${LIBLAVA_EXT_DIR}/Vulkan-Headers/include
-        ${LIBLAVA_EXT_DIR}/VulkanMemoryAllocator/src
-        ${LIBLAVA_EXT_DIR}/volk
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/Vulkan-Headers/include>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/VulkanMemoryAllocator/src>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/volk>
         )
 
 target_link_libraries(lava.base 
@@ -162,11 +159,11 @@ add_library(lava.resource STATIC
         )
 
 target_include_directories(lava.resource PUBLIC
-        ${LIBLAVA_EXT_DIR}/stb
-        ${LIBLAVA_EXT_DIR}/gli
-        ${LIBLAVA_EXT_DIR}/tinyobjloader
-        ${LIBLAVA_EXT_DIR}/bitmap
-        ${LIBLAVA_EXT_DIR}/selene
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/stb>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/gli>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/tinyobjloader>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/bitmap>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/selene>
         )
 
 message(">>> selene")
@@ -200,8 +197,8 @@ add_library(lava.frame STATIC
         )
 
 target_include_directories(lava.frame PUBLIC
-        ${LIBLAVA_EXT_DIR}/glfw/include
-        ${LIBLAVA_EXT_DIR}/argh
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/glfw/include>
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/argh>
         )
 
 message(">>> glfw")
@@ -262,7 +259,7 @@ add_library(lava.app STATIC
         )
 
 target_include_directories(lava.app PUBLIC
-        ${LIBLAVA_EXT_DIR}/imgui
+        $<BUILD_INTERFACE:${LIBLAVA_EXT_DIR}/imgui>
         )
 
 target_link_libraries(lava.app 
@@ -283,6 +280,83 @@ if(LAVA_TESTS)
                 )
 
         target_link_libraries(lava lava::app)
+
+        install(TARGETS
+                lava
+                RUNTIME DESTINATION bin
+                )
 endif()
+
+set(CONFIG_PATH lib/cmake/lava)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfigVersion.cmake"
+        COMPATIBILITY AnyNewerVersion
+        )
+
+configure_package_config_file(
+        cmake/LavaConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfig.cmake"
+        INSTALL_DESTINATION ${CONFIG_PATH}
+        )
+
+install(TARGETS
+        lava.core
+        lava.util
+        lava.base
+        lava.resource
+        lava.frame
+        lava.block
+        lava.app
+        spdlog
+        physfs-static
+        glfw
+        EXPORT LavaTargets
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        CONFIGURATIONS Debug Release
+        INCLUDES DESTINATION include include/liblava/ext
+        )
+
+install(DIRECTORY
+        ${LIBLAVA_DIR}
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.hpp"
+        )
+
+install(DIRECTORY
+        ${LIBLAVA_EXT_DIR}/glm/glm
+        #${LIBLAVA_EXT_DIR}/physfs/src/
+        ${LIBLAVA_EXT_DIR}/json/single_include/
+        ${LIBLAVA_EXT_DIR}/spdlog/include/
+        ${LIBLAVA_EXT_DIR}/Vulkan-Headers/include/
+        ${LIBLAVA_EXT_DIR}/VulkanMemoryAllocator/src/
+        ${LIBLAVA_EXT_DIR}/volk/
+        #${LIBLAVA_EXT_DIR}/stb/
+        #${LIBLAVA_EXT_DIR}/gli/gli
+        #${LIBLAVA_EXT_DIR}/tinyobjloader/
+        #${LIBLAVA_EXT_DIR}/bitmap/
+        #${LIBLAVA_EXT_DIR}/selene/selene
+        #${LIBLAVA_EXT_DIR}/glfw/include/
+        ${LIBLAVA_EXT_DIR}/argh/
+        ${LIBLAVA_EXT_DIR}/imgui/
+        DESTINATION include/liblava/ext
+        FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h" PATTERN "*.inl"
+        )
+
+install(EXPORT LavaTargets
+        DESTINATION ${CONFIG_PATH}
+        FILE LavaTargets.cmake
+        CONFIGURATIONS Debug Release
+        EXPORT_LINK_INTERFACE_LIBRARIES
+        )
+
+install(
+        FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/lava/LavaConfig.cmake"
+        DESTINATION ${CONFIG_PATH}
+        )
 
 message("========================================================================")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,13 +352,13 @@ set(CONFIG_PATH lib/cmake/lava)
 include(CMakePackageConfigHelpers)
 
 write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/lava-config-version.cmake"
         COMPATIBILITY AnyNewerVersion
         )
 
 configure_package_config_file(
         cmake/LavaConfig.cmake.in
-        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/lava-config.cmake"
         INSTALL_DESTINATION ${CONFIG_PATH}
         )
 
@@ -371,8 +371,8 @@ install(EXPORT LavaTargets
 
 install(
         FILES
-        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfigVersion.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LavaConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/lava-config-version.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/lava-config.cmake"
         DESTINATION ${CONFIG_PATH}
         )
 

--- a/cmake/LavaConfig.cmake.in
+++ b/cmake/LavaConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/LavaTargets.cmake")


### PR DESCRIPTION
This PR lets you install liblava as well as find and link it from CMake. It's an alternative to adding it as a project subdirectory and allows you to compile and use specific versions of lava. Inspired by https://github.com/liblava/liblava/issues/3.

Tested on Win 10 (MSVC) + WSL (G++ 8)

# Installing

**Command line:**
```bash
mkdir build & cd build
cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=../lava-install ..
cmake --build . --target install
```

# Linking

**CMakeLists.txt:**
```cmake
find_package(lava 0.5.1 REQUIRED)

add_executable(test main.cpp)
target_link_libraries(test lava::app)
```

**Command line:**
```bash
mkdir build & cd build
cmake -D CMAKE_BUILD_TYPE=Release -D lava_DIR=path/to/lava-install/lib/cmake/lava ..
cmake --build .
```

## Notes

- Since all of the libraries are bundled, external headers must be copied as well. To not pollute /usr/include during a standard install, they are installed to include/liblava/ext/
- Not all external headers are installed, only the ones that are actually linked to from lava includes. This could be changed if you think it makes sense to use 'private' libraries like glfw (the lines are commented out at `install(DIRECTORY ...)`).
- ~~CMake doesn't want to export library aliases, so all targets are exported as lava.core instead of lava::core. This could be worked around by defining aliases again in *LavaConfig.cmake.in* or by defining targets as core, util, etc. and defining a namespace "lava::" at `install(EXPORT ...)`~~
- CMake doesn't like exporting interface sources so I removed them from lava.core for now. ~~Not sure if there's a workaround; an empty static library with no cpp files didn't work (linker error for missing .lib that was never produced)~~ Possible workaround below.