### PR TITLE
Clang support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,6 @@ message("=======================================================================
 
 message("> module")
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-        set_property(GLOBAL PROPERTY ALLOW_DUPLICATE_CUSTOM_TARGETS ON)
-endif()
-
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
         set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
 endif()
@@ -39,9 +35,7 @@ set(LIBLAVA_TESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
 message(">> lava::core")
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-        find_package(Threads)
-endif()
+find_package(Threads REQUIRED)
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp "")
 
@@ -64,10 +58,13 @@ target_compile_features(lava.core INTERFACE
         cxx_std_20
         )
 
-if(CMAKE_COMPILER_IS_GNUCXX)
+target_link_libraries(lava.core INTERFACE
+        Threads::Threads
+        )
+
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "^(GNU|Clang)$")
         target_link_libraries(lava.core INTERFACE 
-                stdc++fs 
-                ${CMAKE_THREAD_LIBS_INIT}
+                stdc++fs
                 )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ target_link_libraries(lava.core INTERFACE
         Threads::Threads
         )
 
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "^(GNU|Clang)$")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         target_link_libraries(lava.core INTERFACE 
                 stdc++fs
                 )


### PR DESCRIPTION
A few small changes to allow compiling with Clang. Tested on Linux (WSL) with Clang 9 and Win 10 with clang-cl (integrated Clang coming with VS 2019).

I removed the `ALLOW_DUPLICATE_CUSTOM_TARGETS` because it doesn't seem to be doing anything. Let me know if it breaks anything on your setup.

This still doesn't allow using Clang with libc++ instead of libstc++, which is only really a concern for automated build systems. This PR was in preparation for the conan package recipe which would theoretically allow you to change the C++ lib. But libstc++ is still the standard on Linux from what I've read, and (correct me if I'm wrong) lava doesn't compile on Mac or Android where libc++ is standard.