### PR TITLE
Create command pools without reset flag

### DIFF
--- a/liblava/block/block.cpp
+++ b/liblava/block/block.cpp
@@ -47,7 +47,7 @@ bool block::create(lava::device_ptr d, index frame_count, index queue_family) {
         VkCommandPoolCreateInfo const create_info 
         {
             .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-            .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+            .flags = 0,
             .queueFamilyIndex = queue_family,
         };
         if (failed(device->call().vkCreateCommandPool(device->get(), &create_info, memory::alloc(), &cmd_pools.at(i)))) {


### PR DESCRIPTION
Minor change to make the [best practices validation layer](https://vulkan.lunarg.com/doc/view/1.1.126.0/windows/best_practices.html) happy.

> [warning] Validation Performance Warning: [ UNASSIGNED-BestPractices-vkCreateCommandPool-command-buffer-reset ] Object 0: handle = 0x181084581d0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x8728e724 | vkCreateCommandPool(): VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT is set. Consider resetting entire pool instead.

> VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT allows any command buffer allocated from a pool to be individually reset to the initial state; either by calling vkResetCommandBuffer, or via the implicit reset when calling vkBeginCommandBuffer. If this flag is not set on a pool, then vkResetCommandBuffer must not be called for any command buffer allocated from that pool.

Since lava doesn't call `vkResetCommandBuffer` and the frame's command pool is reset right before `vkBeginCommandBuffer` this flag is unnecessary.