### PR TITLE
allow using align_up with types that don't have operator-(int)

### DIFF
--- a/liblava/core/data.hpp
+++ b/liblava/core/data.hpp
@@ -29,7 +29,7 @@ template <typename T>
 inline data_ptr as_ptr(T* value) { return (data_ptr)value; }
 
 template <typename T>
-inline T align_up(T val, T align) { return (val + align - 1) / align * align; }
+inline T align_up(T val, T align) { return (val + align - T(1)) / align * align; }
 
 inline size_t align(size_t size, size_t min = 0) {
 


### PR DESCRIPTION
Tiny fix that allows using `align_up` with things like `glm::uvec3`:

```c++
glm::uvec3 groups = lava::align_up(glm::uvec3(scene.main_camera.viewport.zw, 1u), THREADS) / THREADS;
app.device->call().vkCmdDispatch(cmd_buf, groups.x, groups.y, groups.z);
```

Without this change, I'm getting:
> Error C2676 binary '-': 'glm::vec<3,glm::uint,glm::packed_highp>' does not define this operator or a conversion to a type acceptable to the predefined operator