### PR TITLE
Align font icons

### DIFF
--- a/liblava/app/gui.cpp
+++ b/liblava/app/gui.cpp
@@ -148,6 +148,7 @@ namespace lava {
 
             ImFontConfig icons_config;
             icons_config.MergeMode = true;
+            icons_config.GlyphMinAdvanceX = config.icon.size;
             icons_config.PixelSnapH = true;
             icons_config.FontDataOwnedByAtlas = false;
 


### PR DESCRIPTION
This change aligns font icons horizontally by making imgui create a font atlas with fixed icon glyph size.

before:
![before](https://user-images.githubusercontent.com/907940/88463329-23e60880-ceb2-11ea-99f5-fcb0471f85c5.png)

after:
![after](https://user-images.githubusercontent.com/907940/88463333-2ea09d80-ceb2-11ea-9612-e40dad90aed0.png)

If you think this might be unwanted in some scenarios (although I can't personally think of any), I could also put this behind a setting.