### PR TITLE
Fix external subpass dependencies

### DIFF
--- a/liblava/app/forward_shading.cpp
+++ b/liblava/app/forward_shading.cpp
@@ -34,13 +34,17 @@ namespace lava {
             pass->add(subpass);
 
             auto first_subpass_dependency = make_subpass_dependency(VK_SUBPASS_EXTERNAL, 0);
-            first_subpass_dependency->set_stage_mask(VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-            first_subpass_dependency->set_access_mask(VK_ACCESS_MEMORY_READ_BIT, VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+            first_subpass_dependency->set_stage_mask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                                                     VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
+            first_subpass_dependency->set_access_mask(VK_ACCESS_MEMORY_READ_BIT,
+                                                      VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
             pass->add(first_subpass_dependency);
 
             auto second_subpass_dependency = make_subpass_dependency(0, VK_SUBPASS_EXTERNAL);
-            second_subpass_dependency->set_stage_mask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
-            second_subpass_dependency->set_access_mask(VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, VK_ACCESS_MEMORY_READ_BIT);
+            second_subpass_dependency->set_stage_mask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                                                      VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+            second_subpass_dependency->set_access_mask(VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
+                                                       VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
             pass->add(second_subpass_dependency);
         }
 


### PR DESCRIPTION
I found a few issues with the [synchronization validation](https://vulkan.lunarg.com/doc/sdk/1.2.148.0/windows/synchronization_usage.html) from the latest SDK.

### external -> 0:

- src stage doesn't need bottom of pipe, `COLOR_ATTACHMENT_OUTPUT` and `LATE_FRAGMENT_TESTS` is all we need to wait for attachment writes
- dst stage needs to include `EARLY_FRAGMENT_TESTS` since that's where depth/stencil load ops happen (in this case: clear)
- dst access mask also needs to consider depth/stencil writes

### 0 -> external:

- src stage needs `LATE_FRAGMENT_TESTS` to wait for depth attachment writes
- src access mask also needs to consider depth/stencil writes
- dst access mask includes memory writes to prevent write-after-write (although you could possibly argue that writing to an attachment would require a layout transition, at which point the user might as well do explicit synchronization)