### PR TITLE
custom allocator support

### DIFF
--- a/liblava/base/memory.cpp
+++ b/liblava/base/memory.cpp
@@ -110,6 +110,9 @@ namespace lava {
             .vkBindBufferMemory2KHR = vkBindBufferMemory2KHR,
             .vkBindImageMemory2KHR = vkBindImageMemory2KHR,
 #endif
+#if VMA_MEMORY_BUDGET
+            .vkGetPhysicalDeviceMemoryProperties2KHR = vkGetPhysicalDeviceMemoryProperties2KHR
+#endif
         };
 
         VmaAllocatorCreateInfo allocator_info{

--- a/liblava/base/memory.cpp
+++ b/liblava/base/memory.cpp
@@ -126,6 +126,10 @@ namespace lava {
         check(vmaCreateAllocator(&allocator_info, &vma_allocator));
     }
 
+    allocator::allocator(VmaAllocator allocator) {
+        vma_allocator = allocator;
+    }
+
     allocator::~allocator() {
         if (!vma_allocator)
             return;

--- a/liblava/base/memory.hpp
+++ b/liblava/base/memory.hpp
@@ -15,6 +15,7 @@ namespace lava {
 
     struct allocator {
         explicit allocator(VkPhysicalDevice physical_device, VkDevice device);
+        explicit allocator(VmaAllocator allocator);
         ~allocator();
 
         using ptr = std::shared_ptr<allocator>;


### PR DESCRIPTION
Tiny change that allows you to set a custom `VmaAllocator` handle in `allocator` if you need different function pointers, creation flags, etc.