### PR TITLE
Add support for getting buffer address (VK_KHR_buffer_device_address)

### DIFF
--- a/liblava/resource/buffer.cpp
+++ b/liblava/resource/buffer.cpp
@@ -105,6 +105,18 @@ namespace lava {
         device = nullptr;
     }
 
+    VkDeviceAddress buffer::get_address() const {
+        if (device->call().vkGetBufferDeviceAddressKHR) {
+            VkBufferDeviceAddressInfoKHR addr_info{
+                .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR,
+                .buffer = vk_buffer
+            };
+            return device->call().vkGetBufferDeviceAddressKHR(device->get(), &addr_info);
+        } else {
+            return 0;
+        }
+    }
+
     void buffer::flush(VkDeviceSize offset, VkDeviceSize size) {
         vmaFlushAllocation(device->alloc(), allocation, offset, size);
     }

--- a/liblava/resource/buffer.hpp
+++ b/liblava/resource/buffer.hpp
@@ -45,6 +45,7 @@ namespace lava {
             return get_descriptor();
         }
 
+        VkDeviceAddress get_address() const;
         VkDeviceSize get_size() const {
             return allocation_info.size;
         }


### PR DESCRIPTION
Fairly useful to have for the raytracing extensions, but also for neat stuff like [buffer references](https://developer.nvidia.com/blog/improved-glsl-syntax-vulkans-descriptorset-indexing/). But if you think it's too specific to add to lava, that's fine.

re: the function pointer check: the spec [says](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceProcAddr.html) `vkGetDeviceProcAddr` returns `nullptr` for functions of extensions that are not enabled.