### PR TITLE
Fix for file::get_size

### DIFF
--- a/liblava/file/file.cpp
+++ b/liblava/file/file.cpp
@@ -77,13 +77,13 @@ namespace lava {
         } else if (type == file_type::f_stream) {
             if (write_mode) {
                 auto current = o_stream.tellp();
-                o_stream.seekp(std::ostream::end);
+                o_stream.seekp(0, std::ostream::end);
                 auto result = o_stream.tellp();
                 o_stream.seekp(current);
                 return result;
             } else {
                 auto current = i_stream.tellg();
-                i_stream.seekg(std::istream::end);
+                i_stream.seekg(0, std::istream::end);
                 auto result = i_stream.tellg();
                 i_stream.seekg(current);
                 return result;


### PR DESCRIPTION
This fixes a bug that got introduced in https://github.com/liblava/liblava/commit/36390da6a60b093fba25b6a2ddc9541fa6813992. `seek` with one argument only takes an offset, and `ios_base::seekdir::end` is implicitly converted to 2, so `get_size` always returned a size of 2.