### PR TITLE
Fix for incorrect imgui theme colors with sRGB backbuffer

### DIFF
--- a/liblava/app/app.cpp
+++ b/liblava/app/app.cpp
@@ -172,6 +172,9 @@ namespace lava {
         if (!imgui.create(device, target->get_frame_count(), shading.get_vk_pass()))
             return false;
 
+        if (format_srgb(target->get_format()))
+            imgui.convert_style_to_srgb();
+
         shading.get_pass()->add(imgui.get_pipeline());
 
         imgui_fonts = make_texture();

--- a/liblava/app/imgui.cpp
+++ b/liblava/app/imgui.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include <imgui.h>
+#include <glm/gtc/color_space.hpp>
 
 namespace lava {
 
@@ -125,16 +126,21 @@ namespace lava {
         io.KeyMap[ImGuiKey_Z] = GLFW_KEY_Z;
 
         auto& style = ImGui::GetStyle();
-        style.Colors[ImGuiCol_TitleBg] = ImVec4(0.8f, 0.f, 0.f, 0.4f);
-        style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.8f, 0.f, 0.0f, 1.f);
-        style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(1.f, 0.f, 0.f, 0.1f);
-        style.Colors[ImGuiCol_MenuBarBg] = ImVec4(1.f, 0.f, 0.f, 0.4f);
-        style.Colors[ImGuiCol_Header] = ImVec4(0.8f, 0.f, 0.f, 0.4f);
-        style.Colors[ImGuiCol_HeaderActive] = ImVec4(1.f, 0.f, 0.f, 0.4f);
-        style.Colors[ImGuiCol_HeaderHovered] = ImVec4(1.f, 0.f, 0.f, 0.5f);
-        style.Colors[ImGuiCol_CheckMark] = ImVec4(1.f, 0.f, 0.f, 0.8f);
-        style.Colors[ImGuiCol_WindowBg] = ImVec4(0.059f, 0.059f, 0.059f, 0.863f);
-        style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.f, 0.f, 0.f, 0.0f);
+        if (config.style) {
+            style = *config.style;
+        } else {
+            ImGui::StyleColorsDark();
+            style.Colors[ImGuiCol_TitleBg] = ImVec4(0.8f, 0.f, 0.f, 0.4f);
+            style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.8f, 0.f, 0.0f, 1.f);
+            style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(1.f, 0.f, 0.f, 0.1f);
+            style.Colors[ImGuiCol_MenuBarBg] = ImVec4(1.f, 0.f, 0.f, 0.4f);
+            style.Colors[ImGuiCol_Header] = ImVec4(0.8f, 0.f, 0.f, 0.4f);
+            style.Colors[ImGuiCol_HeaderActive] = ImVec4(1.f, 0.f, 0.f, 0.4f);
+            style.Colors[ImGuiCol_HeaderHovered] = ImVec4(1.f, 0.f, 0.f, 0.5f);
+            style.Colors[ImGuiCol_CheckMark] = ImVec4(1.f, 0.f, 0.f, 0.8f);
+            style.Colors[ImGuiCol_WindowBg] = ImVec4(0.059f, 0.059f, 0.059f, 0.863f);
+            style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.f, 0.f, 0.f, 0.0f);
+        }
 
         if (config.font_data.ptr) {
             ImFontConfig font_config;
@@ -440,6 +446,15 @@ namespace lava {
         ini_file = dir.string();
 
         ImGui::GetIO().IniFilename = str(ini_file);
+    }
+
+    void imgui::convert_style_to_srgb() {
+        ImGuiStyle& style = ImGui::GetStyle();
+        for (size_t i = 0; i < ImGuiCol_COUNT; i++) {
+            glm::vec3 srgb = glm::make_vec3(&style.Colors[i].x);
+            glm::vec3 linear = glm::convertSRGBToLinear(srgb);
+            style.Colors[i] = ImVec4(linear.x, linear.y, linear.z, style.Colors[i].w);
+        }
     }
 
     void imgui::invalidate_device_objects() {

--- a/liblava/app/imgui.hpp
+++ b/liblava/app/imgui.hpp
@@ -13,6 +13,7 @@
 struct GLFWwindow;
 struct GLFWcursor;
 struct ImDrawData;
+struct ImGuiStyle;
 
 namespace lava {
 
@@ -53,6 +54,8 @@ namespace lava {
         struct config {
             data font_data;
             r32 font_size = default_imgui_font_size;
+
+            std::shared_ptr<ImGuiStyle> style;
 
             icon_font icon;
 
@@ -107,6 +110,8 @@ namespace lava {
         fs::path get_ini_file() const {
             return fs::path(ini_file);
         }
+
+        void convert_style_to_srgb();
 
     private:
         void handle_key_event(i32 key, i32 scancode, i32 action, i32 mods);

--- a/liblava/resource/format.cpp
+++ b/liblava/resource/format.cpp
@@ -28,6 +28,48 @@ bool lava::format_depth_stencil(VkFormat format) {
     return format_depth(format) || format_stencil(format);
 }
 
+bool lava::format_srgb(VkFormat format)
+{
+    switch (format) {
+    case VK_FORMAT_R8_SRGB:
+    case VK_FORMAT_R8G8_SRGB:
+    case VK_FORMAT_R8G8B8_SRGB:
+    case VK_FORMAT_B8G8R8_SRGB:
+    case VK_FORMAT_R8G8B8A8_SRGB:
+    case VK_FORMAT_B8G8R8A8_SRGB:
+    case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
+    case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
+    case VK_FORMAT_BC2_SRGB_BLOCK:
+    case VK_FORMAT_BC3_SRGB_BLOCK:
+    case VK_FORMAT_BC7_SRGB_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_4x4_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_5x4_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_5x5_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_6x5_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_6x6_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_8x5_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_8x6_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_8x8_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_10x5_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_10x6_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_10x8_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_10x10_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_12x10_SRGB_BLOCK:
+    case VK_FORMAT_ASTC_12x12_SRGB_BLOCK:
+    case VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG:
+    case VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG:
+    case VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG:
+    case VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
 VkImageAspectFlags lava::format_aspect_mask(VkFormat format) {
     switch (format) {
     case VK_FORMAT_UNDEFINED:
@@ -484,10 +526,8 @@ VkSurfaceFormatKHR lava::get_surface_format(VkPhysicalDevice device, VkSurfaceKH
     check(vkGetPhysicalDeviceSurfaceFormatsKHR(device, surface, &count, formats.data()));
 
     if (count == 1) {
-        if (formats[0].format == VK_FORMAT_UNDEFINED)
-            return {
-                VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR
-            };
+        if (formats[0].format == VK_FORMAT_UNDEFINED && !request.formats.empty())
+            return { request.formats.front(), request.color_space };
         else
             return formats[0];
     }

--- a/liblava/resource/format.hpp
+++ b/liblava/resource/format.hpp
@@ -15,6 +15,8 @@ namespace lava {
 
     bool format_depth_stencil(VkFormat format);
 
+    bool format_srgb(VkFormat format);
+
     VkImageAspectFlags format_aspect_mask(VkFormat format);
 
     void format_block_dim(VkFormat format, ui32& width, ui32& height);


### PR DESCRIPTION
Just tried out your changes for sRGB backbuffer support and it works great, thanks 👍 
This PR is an attempt at fixing the remaining issue with imgui colors assuming a non-sRGB backbuffer. `app` now converts the colors from sRGB to linear if it detects `target` using an sRGB format.

There are two more changes:
- users can override the imgui style in the config before `app.setup` to make sure their style gets the same color conversion treatment. if that's unwanted, they can change the style after `app.setup`
- if the swapchain supports all formats, it picks the first from the list of requested formats, not hardcoded `BGRA8_UNORM`

### Pictures for comparison

Old (and new) behavior with non-sRGB backbuffer:
![unorm](https://user-images.githubusercontent.com/907940/107793604-c5ea1700-6d56-11eb-8191-b29706060195.png)

Old behavior with sRGB backbuffer:
![srgb_old](https://user-images.githubusercontent.com/907940/107793699-e31ee580-6d56-11eb-903e-421b9abfd687.png)

New behavior with sRGB backbuffer:
![srgb_corrected](https://user-images.githubusercontent.com/907940/107793736-ee721100-6d56-11eb-9811-7a10ac59906a.png)


The result isn't exactly equal, but I'd say it's a decent temporary fix until imgui gets proper sRGB support.

