### PR TITLE
Fix install instruction for multi-config generators

### DIFF
--- a/doc/Install.md
+++ b/doc/Install.md
@@ -33,7 +33,7 @@ mkdir build
 cd build
 
 cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=../lava-install ..
-cmake --build . --target install
+cmake --build . --config Release --target install
 ```
 
 First find the package in your *CMakeLists.txt*


### PR DESCRIPTION
Minor change that makes the instructions generate release binaries on multi-config CMake generators (e.g. Visual Studio). Alternative: remove build type entirely and let the user figure out what they want.