### PR TITLE
Added a setter for input assembler topology

### DIFF
--- a/liblava/block/graphics_pipeline.cpp
+++ b/liblava/block/graphics_pipeline.cpp
@@ -122,6 +122,11 @@ void graphics_pipeline::set_vertex_input_attributes(VkVertexInputAttributeDescri
 }
 
 //-----------------------------------------------------------------------------
+void graphics_pipeline::set_input_topology(VkPrimitiveTopology const& topology) {
+    info.input_assembly_state.topology = topology;
+}
+
+//-----------------------------------------------------------------------------
 void graphics_pipeline::set_depth_test_and_write(bool enable_test, bool enable_write) {
     info.depth_stencil_state.depthTestEnable = enable_test ? VK_TRUE : VK_FALSE;
     info.depth_stencil_state.depthWriteEnable = enable_write ? VK_TRUE : VK_FALSE;

--- a/liblava/block/graphics_pipeline.hpp
+++ b/liblava/block/graphics_pipeline.hpp
@@ -164,6 +164,13 @@ struct graphics_pipeline : pipeline {
     void set_vertex_input_attributes(VkVertexInputAttributeDescriptions const& attributes);
 
     /**
+     * @brief Set the input assembler's topology.
+     *
+     * @param topology Enum describing polygon primitives
+     */
+    void set_input_topology(VkPrimitiveTopology const& topology);
+
+    /**
      * @brief Set the depth test and write
      * 
      * @param test_enable Enable depth test


### PR DESCRIPTION
I've been using Liblava for a variety of things recently, and I felt like it could've used an easy way to set primitive topology on a pipeline. I read #26, but in my opinion that is not a very obvious solution from the perspective of somebody without deep knowledge of this library, and I think that setting primitive topology is a very basic use-case. Using a function like this was the way I assumed I would be able to do it, and the current way doesn't seem to be documented yet in the guide / tutorial.