### PR TITLE
Added camera matrix getters

### DIFF
--- a/liblava/app/camera.cpp
+++ b/liblava/app/camera.cpp
@@ -166,6 +166,20 @@ void camera::update_projection() {
 }
 
 //-----------------------------------------------------------------------------
+lava::mat4 camera::get_view_matrix() {
+    return view;
+}
+//-----------------------------------------------------------------------------
+lava::mat4 camera::get_projection_matrix() {
+    return projection;
+}
+
+//-----------------------------------------------------------------------------
+lava::mat4 camera::get_viewprojection_matrix() {
+    return projection * view;
+}
+
+//-----------------------------------------------------------------------------
 void camera::upload() {
     memcpy(data->get_mapped_data(), &projection, size);
 }

--- a/liblava/app/camera.cpp
+++ b/liblava/app/camera.cpp
@@ -166,16 +166,16 @@ void camera::update_projection() {
 }
 
 //-----------------------------------------------------------------------------
-lava::mat4 camera::get_view_matrix() {
+mat4 camera::get_view() const {
     return view;
 }
 //-----------------------------------------------------------------------------
-lava::mat4 camera::get_projection_matrix() {
+mat4 camera::get_projection() const {
     return projection;
 }
 
 //-----------------------------------------------------------------------------
-lava::mat4 camera::get_viewprojection_matrix() {
+mat4 camera::get_view_projection() const {
     return projection * view;
 }
 

--- a/liblava/app/camera.hpp
+++ b/liblava/app/camera.hpp
@@ -68,6 +68,27 @@ struct camera : entity {
     void update_view(delta dt, gamepad::ref pad);
 
     /**
+     * @brief Get the camera's 4x4 view matrix.
+     *
+     * @return lava::mat4
+     */
+    lava::mat4 get_view_matrix();
+
+    /**
+     * @brief Get the camera's 4x4 projection matrix.
+     *
+     * @return lava::mat4
+     */
+    lava::mat4 get_projection_matrix();
+
+    /**
+     * @brief Get the camera's combined 4x4 view/projection matrix.
+     *
+     * @return lava::mat4
+     */
+    lava::mat4 get_viewprojection_matrix();
+
+    /**
      * @brief Handle key event
      * 
      * @param event     Key event

--- a/liblava/app/camera.hpp
+++ b/liblava/app/camera.hpp
@@ -68,25 +68,25 @@ struct camera : entity {
     void update_view(delta dt, gamepad::ref pad);
 
     /**
-     * @brief Get the camera's 4x4 view matrix.
+     * @brief Get the camera's 4x4 view matrix
      *
-     * @return lava::mat4
+     * @return mat4    View matrix
      */
-    lava::mat4 get_view_matrix();
+    mat4 get_view() const;
 
     /**
-     * @brief Get the camera's 4x4 projection matrix.
+     * @brief Get the camera's 4x4 projection matrix
      *
-     * @return lava::mat4
+     * @return mat4    Projection matrix
      */
-    lava::mat4 get_projection_matrix();
+    mat4 get_projection() const;
 
     /**
-     * @brief Get the camera's combined 4x4 view/projection matrix.
+     * @brief Get the camera's combined 4x4 view/projection matrix
      *
-     * @return lava::mat4
+     * @return mat4    Combined view/projection matrix
      */
-    lava::mat4 get_viewprojection_matrix();
+    mat4 get_view_projection() const;
 
     /**
      * @brief Handle key event


### PR DESCRIPTION
I wanted to make an MVP matrix on CPU, and saw that the camera's view and projection matrices are private, so I added getter methods for them, as well as a combined view/projection matrix for convenience.