### PR TITLE
Added a scale by vector method to mesh data

### DIFF
--- a/liblava/resource/mesh.hpp
+++ b/liblava/resource/mesh.hpp
@@ -54,6 +54,22 @@ public:
             }
         }
     }
+
+    /**
+     * @brief Scale mesh data by vector
+     *
+     * @tparam PosType   Coordinate element typename
+     *
+     * @param factors    Array of position scaling factors
+     */
+    template<typename PosType = float>
+    void scale_vector(std::array<PosType, 3> factors) {
+        for (T& vertex : vertices) {
+            for (auto i = 0u; i < 3; ++i) {
+                vertex.position[i] *= factors[i];
+            }
+        }
+    }
 };
 
 /**
@@ -157,7 +173,7 @@ struct mesh_template : entity {
      *
      * @param value    Mesh data to add
      */
-    void add_data(mesh_template_data<T> const& value){
+    void add_data(mesh_template_data<T> const& value) {
         data = value;
     }
 


### PR DESCRIPTION
I needed to flip a mesh by {1, -1, 1}, so I wrote this. By taking in a 3 element vector this way, it could also be used to make meshes fatter or taller.