### PR TITLE
Made camera controls customizable

### DIFF
--- a/liblava/app/camera.cpp
+++ b/liblava/app/camera.cpp
@@ -186,28 +186,37 @@ void camera::upload() {
 
 //-----------------------------------------------------------------------------
 bool camera::handle(key_event::ref event) {
-    switch (event.key) {
-    case key::w: {
-        up = event.active();
-        break;
-    }
-    case key::s: {
-        down = event.active();
-        break;
-    }
-    case key::a: {
-        left = event.active();
-        break;
-    }
-    case key::d: {
-        right = event.active();
-        break;
-    }
-    default:
+    key pressed_key = event.key;
+    auto check_key = [&](key current_key, key testing_key, bool& value) -> bool {
+        if (current_key == testing_key) {
+            value = event.active();
+            return input_done;
+        }
         return input_ignore;
+    };
+
+    for (auto& current_key : up_key) {
+        if (check_key(current_key, pressed_key, up)) {
+            return input_done;
+        }
+    }
+    for (auto& current_key : down_key) {
+        if (check_key(current_key, pressed_key, down)) {
+            return input_done;
+        }
+    }
+    for (auto& current_key : left_key) {
+        if (check_key(current_key, pressed_key, left)) {
+            return input_done;
+        }
+    }
+    for (auto& current_key : right_key) {
+        if (check_key(current_key, pressed_key, right)) {
+            return input_done;
+        }
     }
 
-    return input_done;
+    return input_ignore;
 }
 
 //-----------------------------------------------------------------------------

--- a/liblava/app/camera.hpp
+++ b/liblava/app/camera.hpp
@@ -185,10 +185,10 @@ struct camera : entity {
     /**
      * @brief Set keys for moving this camera.
      *
-     * @param up        Up input
-     * @param down      Down input
-     * @param left      Left input
-     * @param right     Right input
+     * @param up        Up inputs
+     * @param down      Down inputs
+     * @param left      Left inputs
+     * @param right     Right inputs
      */
     void set_movement_keys(std::vector<key> up, std::vector<key> down,
                            std::vector<key> left, std::vector<key> right) {
@@ -272,16 +272,16 @@ private:
     /// Scroll position
     r64 scroll_pos = 0.0;
 
-    /// Up input keycode
+    /// Up input keycodes
     std::vector<key> up_key = std::vector<key>{ key::w };
 
-    /// Down input keycode
+    /// Down input keycodes
     std::vector<key> down_key = std::vector<key>{ key::s };
 
-    /// Left input keycode
+    /// Left input keycodes
     std::vector<key> left_key = std::vector<key>{ key::a };
 
-    /// Right input keycode
+    /// Right input keycodes
     std::vector<key> right_key = std::vector<key>{ key::d };
 
     /// Vulkan buffer

--- a/liblava/app/camera.hpp
+++ b/liblava/app/camera.hpp
@@ -182,6 +182,22 @@ struct camera : entity {
         return up || down || left || right;
     }
 
+    /**
+     * @brief Set keys for moving this camera.
+     *
+     * @param up        Up input
+     * @param down      Down input
+     * @param left      Left input
+     * @param right     Right input
+     */
+    void set_movement_keys(std::vector<key> up, std::vector<key> down,
+                           std::vector<key> left, std::vector<key> right) {
+        up_key = up;
+        down_key = down;
+        left_key = left;
+        right_key = right;
+    }
+
     /// Camera position
     v3 position = v3(0.f);
 
@@ -255,6 +271,18 @@ private:
 
     /// Scroll position
     r64 scroll_pos = 0.0;
+
+    /// Up input keycode
+    std::vector<key> up_key = std::vector<key>{ key::w };
+
+    /// Down input keycode
+    std::vector<key> down_key = std::vector<key>{ key::s };
+
+    /// Left input keycode
+    std::vector<key> left_key = std::vector<key>{ key::a };
+
+    /// Right input keycode
+    std::vector<key> right_key = std::vector<key>{ key::d };
 
     /// Vulkan buffer
     buffer::ptr data;


### PR DESCRIPTION
I use the [Hands Down](https://sites.google.com/alanreiser.com/handsdown) family instead of the QWERTY keyboard layout, and I use [home-row mod keys](https://precondition.github.io/home-row-mods). For these reasons, I (and anybody else with this fairly popular kind of setup, at least among keyboard nerds) need the inputs to be rebindable to one or multiple keys. In my current project, I now have this line:
```c++
  app.camera.set_movement_keys({lava::key::m},
                               {lava::key::n, lava::key::left_control},
                               {lava::key::s, lava::key::left_super},
                               {lava::key::t, lava::key::left_alt});
```
This PR keeps WASD as the default control scheme.