### PR TITLE
Added support for VkPhysicalDevice2

### DIFF
--- a/liblava/base/device.cpp
+++ b/liblava/base/device.cpp
@@ -108,7 +108,7 @@ bool device::create(create_param::ref param) {
         .ppEnabledLayerNames = nullptr,
         .enabledExtensionCount = to_ui32(param.extensions.size()),
         .ppEnabledExtensionNames = param.extensions.data(),
-        .pEnabledFeatures = &param.features,
+        .pEnabledFeatures = (param.has_features_2) ? nullptr : &param.features,
     };
 
     if (failed(vkCreateDevice(physical_device->get(), &create_info, memory::alloc(), &vk_device))) {

--- a/liblava/base/device.hpp
+++ b/liblava/base/device.hpp
@@ -48,6 +48,9 @@ struct device : device_table, entity {
         /// List of physical device features to enable
         VkPhysicalDeviceFeatures features{};
 
+        /// Must be true if .next points to a VkPhysicalDevice2 instance
+        bool has_features_2 = false;
+
         /// Create parameter next pointer (pNext)
         void const* next = nullptr;
 


### PR DESCRIPTION
This is a pretty low-tech way to make VkPhysicalDevice2 work in my project. As discussed in the Discord server, there's currently no very clear way to do this. I thought about ways to automate this, because I feel like C++ should provide some metaprogramming tools to figure out if we have a VkPhysicalDevice or VkPhysicalDevice2, but nothing that I tried work.
