### PR TITLE
Macos build

### DIFF
--- a/liblava/core/hex.hpp
+++ b/liblava/core/hex.hpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <liblava/core/types.hpp>
 #include <numbers>
+#include <unordered_map>
 
 namespace lava {
 

--- a/liblava/frame/input.hpp
+++ b/liblava/frame/input.hpp
@@ -700,6 +700,11 @@ using input_t = input;
  * @brief Tooltip
  */
 struct tooltip {
+    /// tooltip Constructor
+    tooltip(std::string name, lava::key key, lava::mod mod)
+        : name(std::move(name)), key(key), mod(mod) {
+    }
+
     /// List of tooltips
     using list = std::vector<tooltip>;
 


### PR DESCRIPTION
To be able to compile in macos I had to do two changes:

1. std::unordered_map is used in livlava/core/hex.hpp in line 56 and there is no #inlcude<unordered_map> defined.
2. The function tooltips.emplace_back in liblava/app/app.hpp uses the tooltip struct but it requires a constructor, as the tooltip doesn't have a constructor the function fails with the error "..no matching function for call to 'construct_at'..". So a constructor was added to struct tooltip.

