### PR TITLE
Macos

### DIFF
--- a/liblava/base/instance.cpp
+++ b/liblava/base/instance.cpp
@@ -21,9 +21,9 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL
                         VkDebugUtilsMessageTypeFlagsEXT message_type,
                         const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
                         void* user_data) {
-    auto message_header = fmt::format("validation: {} ({})",
-                                      callback_data->pMessageIdName,
-                                      callback_data->messageIdNumber);
+    auto message_header = callback_data->pMessageIdName != nullptr ?
+        fmt::format("validation: {} ({})", callback_data->pMessageIdName, callback_data->messageIdNumber) :
+        fmt::format("validation: ({})", callback_data->messageIdNumber);
 
     if (message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
         log()->error(str(message_header));

--- a/liblava/base/instance.cpp
+++ b/liblava/base/instance.cpp
@@ -130,6 +130,9 @@ bool instance::create(create_param& param,
         .ppEnabledLayerNames = param.layers.data(),
         .enabledExtensionCount = to_ui32(param.extensions.size()),
         .ppEnabledExtensionNames = param.extensions.data(),
+#ifdef __APPLE__
+        .flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR,
+#endif
     };
 
     if (!profile.empty()) {

--- a/liblava/core/data.hpp
+++ b/liblava/core/data.hpp
@@ -114,7 +114,11 @@ inline void* alloc_data(size_t size,
 #if _WIN32
     return _aligned_malloc(size, alignment);
 #else
-    return aligned_alloc(alignment, size);
+    if(size % alignment == 0) {
+        return aligned_alloc(alignment, size);
+    } else {
+        return aligned_alloc(alignment, ((size / alignment) + 1) * alignment);
+    }
 #endif
 }
 

--- a/liblava/frame/frame.cpp
+++ b/liblava/frame/frame.cpp
@@ -148,6 +148,10 @@ bool frame::setup() {
     for (auto i = 0u; i < glfw_extensions_count; ++i)
         env.param.extensions.push_back(glfw_extensions[i]);
 
+#ifdef __APPLE__
+    env.param.extensions.push_back("VK_KHR_portability_enumeration");
+#endif
+
     if (!instance::singleton().create(env.param, env.debug, env.info, env.profile)) {
         log()->error("create instance");
         return false;


### PR DESCRIPTION
1. callback_data->pMessageIdName sometimes is a NULL string and fmt::format("validation: {} ({})", callback_data->pMessageIdName, callback_data->messageIdNumber); causes an error, so I added a validation if it is NULL only do fmt::format("validation: ({})", callback_data->messageIdNumber);
2. The newest releases of VulkanSDK require that Apple M1 add the extension VK_KHR_portability_enumeration and a flag in create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR. This code was added inside a #ifdef __APPLE__ to not disturb Linux and/or Microsoft
3. VK_ERROR_OUT_OF_HOST_MEMORY error is because Vulkan instance cannot be created because it is using use_custom_cpu_callbacks and the function custom_cpu_allocation is calling aligned_alloc with a size that is not a multiple of alignment and that is a requirement (MS _aligned_malloc  does not have this requirement). So the size is adjusted to be a multiple of alignment for this case as follows: return aligned_alloc(alignment, ((size / alignment) + 1) * alignment);

This changes made all examples to work on MacOS