### PR TITLE
Added support for user definable semaphores to renderer to synchronization with own command buffers. 

### DIFF
--- a/liblava/base/base.hpp
+++ b/liblava/base/base.hpp
@@ -92,6 +92,9 @@ using VkVertexInputAttributeDescriptions = std::vector<VkVertexInputAttributeDes
 /// List of Vulkan pipeline color blend attachment states
 using VkPipelineColorBlendAttachmentStates = std::vector<VkPipelineColorBlendAttachmentState>;
 
+/// List of Vulkan pipeline stage flags
+using VkPipelineStageFlagsList = std::vector<VkPipelineStageFlags>;
+
 /// List of Vulkan dynamic states
 using VkDynamicStates = std::vector<VkDynamicState>;
 

--- a/liblava/frame/renderer.cpp
+++ b/liblava/frame/renderer.cpp
@@ -7,6 +7,7 @@
 
 #include "liblava/frame/renderer.hpp"
 #include <array>
+#include "liblava/core/misc.hpp"
 
 namespace lava {
 
@@ -153,36 +154,39 @@ optional_index renderer::begin_frame() {
 bool renderer::end_frame(VkCommandBuffers const& cmd_buffers) {
     LAVA_ASSERT(!cmd_buffers.empty());
 
-    std::vector<VkSemaphore> wait_semaphores = {
-            image_acquired_semaphores[current_sync]
+    VkSemaphores wait_semaphores = {
+        image_acquired_semaphores[current_sync]
     };
-    wait_semaphores.insert(wait_semaphores.end(), user_frame_wait_semaphores.begin(), user_frame_wait_semaphores.end());
+    if (!user_frame_wait_semaphores.empty())
+        append(wait_semaphores, user_frame_wait_semaphores);
 
-    std::vector<VkPipelineStageFlags> wait_stages = {
-            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+    VkPipelineStageFlagsList wait_stages = {
+        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
     };
-    wait_stages.insert(wait_stages.end(), user_frame_wait_stages.begin(), user_frame_wait_stages.end());
+    if (!user_frame_wait_stages.empty())
+        append(wait_stages, user_frame_wait_stages);
 
     std::array<VkSemaphore, 1> const sync_present_semaphores = {
-            render_complete_semaphores[current_sync]
+        render_complete_semaphores[current_sync]
     };
 
-    std::vector<VkSemaphore> signal_semaphores = {
-            render_complete_semaphores[current_sync]
+    VkSemaphores signal_semaphores = {
+        render_complete_semaphores[current_sync]
     };
-    signal_semaphores.insert(signal_semaphores.end(), user_frame_signal_semaphores.begin(), user_frame_signal_semaphores.end());
+    if (!user_frame_signal_semaphores.empty())
+        append(signal_semaphores, user_frame_signal_semaphores);
 
     LAVA_ASSERT(user_frame_wait_semaphores.size() == user_frame_wait_stages.size());
 
     VkSubmitInfo const submit_info{
-            .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-            .waitSemaphoreCount = to_ui32(wait_semaphores.size()),
-            .pWaitSemaphores = wait_semaphores.data(),
-            .pWaitDstStageMask = wait_stages.data(),
-            .commandBufferCount = to_ui32(cmd_buffers.size()),
-            .pCommandBuffers = cmd_buffers.data(),
-            .signalSemaphoreCount = to_ui32(signal_semaphores.size()),
-            .pSignalSemaphores = signal_semaphores.data(),
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .waitSemaphoreCount = to_ui32(wait_semaphores.size()),
+        .pWaitSemaphores = wait_semaphores.data(),
+        .pWaitDstStageMask = wait_stages.data(),
+        .commandBufferCount = to_ui32(cmd_buffers.size()),
+        .pCommandBuffers = cmd_buffers.data(),
+        .signalSemaphoreCount = to_ui32(signal_semaphores.size()),
+        .pSignalSemaphores = signal_semaphores.data(),
     };
 
     std::array<VkSubmitInfo, 1> const submit_infos = { submit_info };

--- a/liblava/frame/renderer.hpp
+++ b/liblava/frame/renderer.hpp
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include "liblava/frame/swapchain.hpp"
 #include <optional>
+#include "liblava/frame/swapchain.hpp"
 
 namespace lava {
 
@@ -72,15 +72,14 @@ struct renderer : entity {
         return device;
     }
 
-    ///The frame waits additionally for these semaphores (Usefully for additional CommandBuffers)
-    std::vector<VkSemaphore> user_frame_wait_semaphores{};
+    /// The frame waits additionally for these semaphores (Usefully for additional CommandBuffers)
+    VkSemaphores user_frame_wait_semaphores;
 
-    ///To user_frame_wait_semaphores corresponding pipeline wait stages
-    std::vector<VkPipelineStageFlags> user_frame_wait_stages{};
+    /// To user_frame_wait_semaphores corresponding pipeline wait stages
+    VkPipelineStageFlagsList user_frame_wait_stages;
 
-    ///The frame additionally signals these semaphores (Usefully for additional CommandBuffers)
-    std::vector<VkSemaphore> user_frame_signal_semaphores{};
-
+    /// The frame additionally signals these semaphores (Usefully for additional CommandBuffers)
+    VkSemaphores user_frame_signal_semaphores;
 
     /// Destroy function
     using destroy_func = std::function<void()>;

--- a/liblava/resource/buffer.cpp
+++ b/liblava/resource/buffer.cpp
@@ -18,17 +18,17 @@ bool buffer::create(device_p d,
                     bool mapped,
                     VmaMemoryUsage memory_usage,
                     VkSharingMode sharing_mode,
-                    const std::vector<uint32_t> &shared_queue_family_indices,
-                    int alignment) {
+                    std::vector<ui32> const& shared_queue_family_indices,
+                    i32 alignment) {
     device = d;
 
     VkBufferCreateInfo buffer_info{
-            .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-            .size = size,
-            .usage = usage,
-            .sharingMode = sharing_mode,
-            .queueFamilyIndexCount = (uint32_t)shared_queue_family_indices.size(),
-            .pQueueFamilyIndices = shared_queue_family_indices.data()
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = size,
+        .usage = usage,
+        .sharingMode = sharing_mode,
+        .queueFamilyIndexCount = to_ui32(shared_queue_family_indices.size()),
+        .pQueueFamilyIndices = shared_queue_family_indices.data()
     };
 
     VmaAllocationCreateFlags const alloc_flags = mapped
@@ -40,18 +40,18 @@ bool buffer::create(device_p d,
         .usage = memory_usage,
     };
 
-    if(alignment >= 0){
+    if (alignment >= 0) {
         if (failed(vmaCreateBufferWithAlignment(device->alloc(),
-                                   &buffer_info,
-                                   &alloc_info,
-                                   alignment,
-                                   &vk_buffer,
-                                   &allocation,
-                                   &allocation_info))) {
-            log()->error("create buffer");
+                                                &buffer_info,
+                                                &alloc_info,
+                                                alignment,
+                                                &vk_buffer,
+                                                &allocation,
+                                                &allocation_info))) {
+            log()->error("create buffer with alignment");
             return false;
         }
-    }else{
+    } else {
         if (failed(vmaCreateBuffer(device->alloc(),
                                    &buffer_info,
                                    &alloc_info,
@@ -62,7 +62,6 @@ bool buffer::create(device_p d,
             return false;
         }
     }
-
 
     if (!mapped) {
         if (data) {
@@ -101,8 +100,8 @@ bool buffer::create_mapped(device_p d,
                            VkBufferUsageFlags usage,
                            VmaMemoryUsage memory_usage,
                            VkSharingMode sharing_mode,
-                           const std::vector<uint32_t> &shared_queue_family_indices,
-                           int alignment) {
+                           std::vector<ui32> const& shared_queue_family_indices,
+                           i32 alignment) {
     return create(d,
                   data,
                   size,

--- a/liblava/resource/buffer.cpp
+++ b/liblava/resource/buffer.cpp
@@ -16,15 +16,18 @@ bool buffer::create(device_p d,
                     size_t size,
                     VkBufferUsageFlags usage,
                     bool mapped,
-                    VmaMemoryUsage memory_usage) {
+                    VmaMemoryUsage memory_usage,
+                    VkSharingMode sharing_mode,
+                    const std::vector<uint32_t> &shared_queue_family_indices) {
     device = d;
 
     VkBufferCreateInfo buffer_info{
-        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-        .size = size,
-        .usage = usage,
-        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
-        .queueFamilyIndexCount = 0,
+            .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+            .size = size,
+            .usage = usage,
+            .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+            .queueFamilyIndexCount = (uint32_t)shared_queue_family_indices.size(),
+            .pQueueFamilyIndices = shared_queue_family_indices.data()
     };
 
     VmaAllocationCreateFlags const alloc_flags = mapped
@@ -81,13 +84,17 @@ bool buffer::create_mapped(device_p d,
                            void const* data,
                            size_t size,
                            VkBufferUsageFlags usage,
-                           VmaMemoryUsage memory_usage) {
+                           VmaMemoryUsage memory_usage,
+                           VkSharingMode sharing_mode,
+                           const std::vector<uint32_t> &shared_queue_family_indices) {
     return create(d,
                   data,
                   size,
                   usage,
                   true,
-                  memory_usage);
+                  memory_usage,
+                  sharing_mode,
+                  shared_queue_family_indices);
 }
 
 //-----------------------------------------------------------------------------

--- a/liblava/resource/buffer.hpp
+++ b/liblava/resource/buffer.hpp
@@ -38,12 +38,14 @@ struct buffer : entity {
 
     /**
      * @brief Create a new buffer
-     * @param device          Vulkan device
-     * @param data            Buffer data
-     * @param size            Data size
-     * @param usage           Buffer usage flags
-     * @param mapped          Map the buffer
-     * @param memory_usage    Memory usage
+     * @param device                 Vulkan device
+     * @param data                   Buffer data
+     * @param size                   Data size
+     * @param usage                  Buffer usage flags
+     * @param mapped                 Map the buffer
+     * @param memory_usage           Memory usage
+     * @param sharing_mode           Sharing mode
+     * @param shared_queue_indices   Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
      * @return Create was successful or failed
      */
     bool create(device_p device,
@@ -51,22 +53,29 @@ struct buffer : entity {
                 size_t size,
                 VkBufferUsageFlags usage,
                 bool mapped = false,
-                VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_GPU_ONLY);
+                VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_GPU_ONLY,
+                VkSharingMode sharing_mode = VK_SHARING_MODE_EXCLUSIVE,
+                const std::vector<uint32_t> &shared_queue_family_indices = {});
 
     /**
      * @brief Create a new mapped buffer
-     * @param device          Vulkan device
-     * @param data            Buffer data
-     * @param size            Data size
-     * @param usage           Buffer usage flags
-     * @param memory_usage    Memory usage
+     * @param device                 Vulkan device
+     * @param data                   Buffer data
+     * @param size                   Data size
+     * @param usage                  Buffer usage flags
+     * @param memory_usage           Memory usage
+     * @param sharing_mode           Sharing mode
+     * @param shared_queue_indices   Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
      * @return Create was successful or failed
      */
     bool create_mapped(device_p device,
                        void const* data,
                        size_t size,
                        VkBufferUsageFlags usage,
-                       VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_CPU_TO_GPU);
+                       VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_CPU_TO_GPU,
+                       VkSharingMode sharing_mode = VK_SHARING_MODE_EXCLUSIVE,
+                       const std::vector<uint32_t> &shared_queue_family_indices = {});
+
 
     /**
      * @brief Destroy the buffer

--- a/liblava/resource/buffer.hpp
+++ b/liblava/resource/buffer.hpp
@@ -38,15 +38,15 @@ struct buffer : entity {
 
     /**
      * @brief Create a new buffer
-     * @param device                 Vulkan device
-     * @param data                   Buffer data
-     * @param size                   Data size
-     * @param usage                  Buffer usage flags
-     * @param mapped                 Map the buffer
-     * @param memory_usage           Memory usage
-     * @param sharing_mode           Sharing mode
-     * @param shared_queue_indices   Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
-     * @param alignment              Minimum alignment to be used when placing the buffer inside a larger memory block negative -> no minimum alignment
+     * @param device                         Vulkan device
+     * @param data                           Buffer data
+     * @param size                           Data size
+     * @param usage                          Buffer usage flags
+     * @param mapped                         Map the buffer
+     * @param memory_usage                   Memory usage
+     * @param sharing_mode                   Sharing mode
+     * @param shared_queue_family_indices    Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
+     * @param alignment                      Minimum alignment to be used when placing the buffer inside a larger memory block negative -> no minimum alignment
      * @return Create was successful or failed
      */
     bool create(device_p device,
@@ -56,19 +56,19 @@ struct buffer : entity {
                 bool mapped = false,
                 VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_GPU_ONLY,
                 VkSharingMode sharing_mode = VK_SHARING_MODE_EXCLUSIVE,
-                const std::vector<uint32_t> &shared_queue_family_indices = {},
-                int alignment = -1);
+                std::vector<ui32> const& shared_queue_family_indices = {},
+                i32 alignment = -1);
 
     /**
      * @brief Create a new mapped buffer
-     * @param device                 Vulkan device
-     * @param data                   Buffer data
-     * @param size                   Data size
-     * @param usage                  Buffer usage flags
-     * @param memory_usage           Memory usage
-     * @param sharing_mode           Sharing mode
-     * @param shared_queue_indices   Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
-     * @param alignment              Minimum alignment to be used when placing the buffer inside a larger memory block negative -> no minimum alignment
+     * @param device                         Vulkan device
+     * @param data                           Buffer data
+     * @param size                           Data size
+     * @param usage                          Buffer usage flags
+     * @param memory_usage                   Memory usage
+     * @param sharing_mode                   Sharing mode
+     * @param shared_queue_family_indices    Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
+     * @param alignment                      Minimum alignment to be used when placing the buffer inside a larger memory block negative -> no minimum alignment
      * @return Create was successful or failed
      */
     bool create_mapped(device_p device,
@@ -77,9 +77,8 @@ struct buffer : entity {
                        VkBufferUsageFlags usage,
                        VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_CPU_TO_GPU,
                        VkSharingMode sharing_mode = VK_SHARING_MODE_EXCLUSIVE,
-                       const std::vector<uint32_t> &shared_queue_family_indices = {},
-                       int alignment = -1);
-
+                       std::vector<ui32> const& shared_queue_family_indices = {},
+                       i32 alignment = -1);
 
     /**
      * @brief Destroy the buffer

--- a/liblava/resource/buffer.hpp
+++ b/liblava/resource/buffer.hpp
@@ -46,6 +46,7 @@ struct buffer : entity {
      * @param memory_usage           Memory usage
      * @param sharing_mode           Sharing mode
      * @param shared_queue_indices   Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
+     * @param alignment              Minimum alignment to be used when placing the buffer inside a larger memory block negative -> no minimum alignment
      * @return Create was successful or failed
      */
     bool create(device_p device,
@@ -55,7 +56,8 @@ struct buffer : entity {
                 bool mapped = false,
                 VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_GPU_ONLY,
                 VkSharingMode sharing_mode = VK_SHARING_MODE_EXCLUSIVE,
-                const std::vector<uint32_t> &shared_queue_family_indices = {});
+                const std::vector<uint32_t> &shared_queue_family_indices = {},
+                int alignment = -1);
 
     /**
      * @brief Create a new mapped buffer
@@ -66,6 +68,7 @@ struct buffer : entity {
      * @param memory_usage           Memory usage
      * @param sharing_mode           Sharing mode
      * @param shared_queue_indices   Queue indices (ignored unless sharing_mode == VK_SHARING_MODE_CONCURRENT)
+     * @param alignment              Minimum alignment to be used when placing the buffer inside a larger memory block negative -> no minimum alignment
      * @return Create was successful or failed
      */
     bool create_mapped(device_p device,
@@ -74,7 +77,8 @@ struct buffer : entity {
                        VkBufferUsageFlags usage,
                        VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_CPU_TO_GPU,
                        VkSharingMode sharing_mode = VK_SHARING_MODE_EXCLUSIVE,
-                       const std::vector<uint32_t> &shared_queue_family_indices = {});
+                       const std::vector<uint32_t> &shared_queue_family_indices = {},
+                       int alignment = -1);
 
 
     /**


### PR DESCRIPTION
A proposal to my Issue #95. 

This change allows to add your own wait/signal semaphores to the vkQueueSubmit call in renderer::end_frame.
Allowing to synchronize additional command buffers with the main render frame command buffers. (useful when working mit multiple command queues). 

Support for timeline semaphores could be interesting too. (set via .pNext for vkQueueSubmit)