### PR TITLE
Fixes mouse coordinates for macos retina screens.

### DIFF
--- a/liblava/app/imgui.cpp
+++ b/liblava/app/imgui.cpp
@@ -108,7 +108,9 @@ void imgui::update_mouse_pos_and_buttons() {
         } else {
             double mouse_x, mouse_y;
             glfwGetCursorPos(window, &mouse_x, &mouse_y);
-            io.MousePos = ImVec2((float) mouse_x, (float) mouse_y);
+            float scale_x, scale_y;
+            glfwGetWindowContentScale(window, &scale_x, &scale_y);
+            io.MousePos = ImVec2((float) mouse_x * scale_x, (float) mouse_y * scale_y);
         }
     }
 }

--- a/liblava/frame/window.cpp
+++ b/liblava/frame/window.cpp
@@ -5,9 +5,9 @@
  * @copyright    Copyright (c) 2018-present, MIT License
  */
 
+#include "liblava/frame/window.hpp"
 #include "liblava/base/device.hpp"
 #include "liblava/base/instance.hpp"
-#include "liblava/frame/window.hpp"
 #include "liblava/util/log.hpp"
 
 #define GLFW_INCLUDE_NONE
@@ -332,6 +332,14 @@ void window::get_mouse_position(r64& x, r64& y) const {
 mouse_position window::get_mouse_position() const {
     mouse_position result;
     get_mouse_position(result.x, result.y);
+
+    return result;
+}
+
+//-----------------------------------------------------------------------------
+v2 window::get_content_scale() const {
+    v2 result;
+    glfwGetWindowContentScale(handle, &result.x, &result.y);
 
     return result;
 }

--- a/liblava/frame/window.hpp
+++ b/liblava/frame/window.hpp
@@ -204,6 +204,12 @@ struct window : entity {
     void get_mouse_position(r64& x, r64& y) const;
 
     /**
+     * @brief Get the content scale
+     * @return v2    Window content scale
+     */
+    v2 get_content_scale() const;
+
+    /**
      * @brief Get the mouse position in window
      * @return mouse_position    Position of mouse
      */


### PR DESCRIPTION
By default the mouse coordinates are in the wrong scale.
I haven't checked this on high-dpi windows or linux screens, so this patch may not be correct for them.

original behaviour:
https://user-images.githubusercontent.com/58549/218182791-0d947f25-1438-4423-a79f-51eae223deb7.mp4
fixed behaviour:
https://user-images.githubusercontent.com/58549/218182770-07891e0d-9555-486a-ad4a-a7a2e0a079e1.mp4




