### PR TITLE
Fix for Swapchain VK_SUBOPTIMAL_KHR crash on Linux

### DIFF
--- a/liblava/base/base.cpp
+++ b/liblava/base/base.cpp
@@ -16,7 +16,11 @@ bool check(VkResult result) {
         return true;
 
     if (result > 0) {
-        log()->critical("VkResult {}", to_string(result));
+        if (result == VK_SUBOPTIMAL_KHR)
+            log()->warn("VkResult {}", to_string(result));
+        else
+            log()->critical("VkResult {}", to_string(result));
+
         return false;
     }
 

--- a/liblava/base/instance.cpp
+++ b/liblava/base/instance.cpp
@@ -32,8 +32,11 @@ VKAPI_ATTR VkBool32 VKAPI_CALL
     if (message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
         log()->error(message_header);
         log()->error(callback_data->pMessage);
-        if (std::string(callback_data->pMessageIdName) != "VUID-VkSwapchainCreateInfoKHR-imageExtent-01274") // unpreventable error application is still ok see: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1340
+
+        // unpreventable error application is still ok see: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1340
+        if (string(callback_data->pMessageIdName) != "VUID-VkSwapchainCreateInfoKHR-imageExtent-01274")
             LAVA_ASSERT(!"check validation error");
+
     } else if (message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
         log()->warn(message_header);
         log()->warn(callback_data->pMessage);

--- a/liblava/base/instance.cpp
+++ b/liblava/base/instance.cpp
@@ -32,8 +32,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL
     if (message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
         log()->error(message_header);
         log()->error(callback_data->pMessage);
-
-        LAVA_ASSERT(!"check validation error");
+        if (std::string(callback_data->pMessageIdName) != "VUID-VkSwapchainCreateInfoKHR-imageExtent-01274") // unpreventable error application is still ok see: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1340
+            LAVA_ASSERT(!"check validation error");
     } else if (message_severity == VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
         log()->warn(message_header);
         log()->warn(callback_data->pMessage);

--- a/liblava/frame/renderer.cpp
+++ b/liblava/frame/renderer.cpp
@@ -115,7 +115,7 @@ optional_index renderer::begin_frame() {
                                                 current_semaphore,
                                                 0,
                                                 &current_frame);
-    if (result.value == VK_ERROR_OUT_OF_DATE_KHR) {
+    if (result.value == VK_ERROR_OUT_OF_DATE_KHR || result.value == VK_SUBOPTIMAL_KHR) {
         target->request_reload();
         return std::nullopt;
     }
@@ -210,7 +210,7 @@ bool renderer::end_frame(VkCommandBuffers const& cmd_buffers) {
     };
 
     auto result = device->vkQueuePresentKHR(graphics_queue.vk_queue, &present_info);
-    if (result.value == VK_ERROR_OUT_OF_DATE_KHR) {
+    if (result.value == VK_ERROR_OUT_OF_DATE_KHR || result.value == VK_SUBOPTIMAL_KHR) {
         target->request_reload();
         return true;
     }


### PR DESCRIPTION
A possible fix for my Issue #99.

By recreating the Swapchain as a result of `VK_SUBOPTIMAL_KHR` in addition to `VK_ERROR_OUT_OF_DATE_KHR` the next call to
`vkAcquireNextImageKHR` doesn't fail anymore.

In addition i prevented the validation error "VUID-VkSwapchainCreateInfoKHR-imageExtent-01274" to cause an assertion error.
This is neccesary due to an "oversight" in the specification https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1340.

If the window is resized between the call to get the new window size and the creation of the Swapchain this validation error is triggered.

This cant be caught, but the application recovers (if we don't kill it via assertion).

It may be a good idea to not log a critical message in `check`  for `VK_SUBOPTIMAL_KHR`, this I have not implemented.