### PR TITLE
Add attachments to forward_shading

### DIFF
--- a/liblava/app/forward_shading.cpp
+++ b/liblava/app/forward_shading.cpp
@@ -35,9 +35,15 @@ bool forward_shading::create(render_target::ptr t) {
                                       VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
         pass->add(depth_attachment);
 
+        for (auto attachment : extra_color_attachments)
+            pass->add(attachment);
+
         auto subpass = subpass::make(VK_PIPELINE_BIND_POINT_GRAPHICS);
-        subpass->set_color_attachment(0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+        subpass->add_color_attachment(0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
         subpass->set_depth_stencil_attachment(1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+        for (size_t i = 0u; i < extra_color_attachments.size(); ++i)
+            subpass->add_color_attachment(i + 2, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+        pass->set_clears_count(2 + extra_color_attachments.size());
         pass->add(subpass);
 
         auto first_subpass_dependency = subpass_dependency::make(VK_SUBPASS_EXTERNAL, 0);
@@ -87,6 +93,9 @@ bool forward_shading::create(render_target::ptr t) {
 
             attachments.push_back(backbuffer->get_view());
             attachments.push_back(depth_stencil->get_view());
+            for (auto& a : extra_image_views) {
+                attachments.push_back(a->get_view());
+            }
 
             result.push_back(attachments);
         }

--- a/liblava/app/forward_shading.hpp
+++ b/liblava/app/forward_shading.hpp
@@ -64,6 +64,9 @@ struct forward_shading {
         return depth_stencil;
     }
 
+    std::vector<attachment::ptr> extra_color_attachments;
+    std::vector<image::ptr> extra_image_views;
+
 private:
     /// Render target
     render_target::ptr target;

--- a/liblava/block/render_pass.cpp
+++ b/liblava/block/render_pass.cpp
@@ -130,14 +130,19 @@ void render_pass::process(VkCommandBuffer cmd_buf,
 
 //-----------------------------------------------------------------------------
 void render_pass::set_clear_color(v3 value) {
-    clear_values.resize(2);
-
     clear_values[0].color.float32[0] = value.r;
     clear_values[0].color.float32[1] = value.g;
     clear_values[0].color.float32[2] = value.b;
     clear_values[0].color.float32[3] = 1.f;
 
     clear_values[1].depthStencil = { 1.f, 0 };
+
+    for (index i = 2u; i < clear_values.size(); ++i) {
+        clear_values[i].color.float32[0] = value.r;
+        clear_values[i].color.float32[1] = value.g;
+        clear_values[i].color.float32[2] = value.b;
+        clear_values[i].color.float32[3] = 1.f;
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/liblava/block/render_pass.hpp
+++ b/liblava/block/render_pass.hpp
@@ -134,6 +134,10 @@ struct render_pass : entity {
         subpasses.push_back(subpass);
     }
 
+    void set_clears_count(index count) {
+        clear_values.resize(count);
+    }
+
     /**
      * @brief Set the clear values
      * @param values    List of clear values
@@ -219,8 +223,8 @@ private:
     /// List of subpasses
     subpass::list subpasses;
 
-    /// List of clear values
-    VkClearValues clear_values = {};
+    /// List of clear values, initialized with at least two.
+    VkClearValues clear_values = VkClearValues(2);
 
     /// Rectangle area
     rect area;

--- a/liblava/block/subpass.cpp
+++ b/liblava/block/subpass.cpp
@@ -69,6 +69,32 @@ void subpass::set_color_attachments(VkAttachmentReferences const& attachments) {
 }
 
 //-----------------------------------------------------------------------------
+void subpass::add_color_attachment(index attachment,
+                                   VkImageLayout layout) {
+    VkAttachmentReference reference;
+    reference.attachment = attachment;
+    reference.layout = layout;
+
+    add_color_attachment(reference);
+}
+
+//-----------------------------------------------------------------------------
+void subpass::add_color_attachment(VkAttachmentReference attachment) {
+    VkAttachmentReferences attachments;
+    attachments.push_back(attachment);
+    add_color_attachments(attachments);
+}
+
+//-----------------------------------------------------------------------------
+void subpass::add_color_attachments(VkAttachmentReferences const& attachments) {
+    for (auto& attachment : attachments)
+        color_attachments.push_back(attachment);
+
+    description.colorAttachmentCount = to_ui32(color_attachments.size());
+    description.pColorAttachments = color_attachments.data();
+}
+
+//-----------------------------------------------------------------------------
 void subpass::set_depth_stencil_attachment(index attachment,
                                            VkImageLayout layout) {
     VkAttachmentReference reference;

--- a/liblava/block/subpass.hpp
+++ b/liblava/block/subpass.hpp
@@ -114,6 +114,11 @@ struct subpass : entity {
      */
     void set_color_attachments(VkAttachmentReferences const& attachments);
 
+    void add_color_attachment(index attachment,
+                              VkImageLayout layout);
+    void add_color_attachment(VkAttachmentReference attachment);
+    void add_color_attachments(VkAttachmentReferences const& attachments);
+
     /**
      * @brief Set the depth stencil attachment
      * @param attachment    Index of attachment


### PR DESCRIPTION
I needed to add attachments in my project. That project isn't published yet, but these changes got it working for me. I can now do this code:

    forward_shading color_shading;

    // The render pass already has color and depth attachments.
    lava::attachment::ptr id_attachment =
        lava::attachment::make(VK_FORMAT_R32_UINT);
    id_attachment->set_op(VK_ATTACHMENT_LOAD_OP_CLEAR,
                          VK_ATTACHMENT_STORE_OP_STORE);
    id_attachment->set_stencil_op(VK_ATTACHMENT_LOAD_OP_DONT_CARE,
                                  VK_ATTACHMENT_STORE_OP_DONT_CARE);
    id_attachment->set_layouts(VK_IMAGE_LAYOUT_UNDEFINED,
                               VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
    color_shading.extra_color_attachments.push_back(id_attachment);

    lava::image::ptr image = lava::image::make(VK_FORMAT_R32_UINT);
    image->set_usage(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);

    image->create(device, {width, height});
    color_shading.extra_image_views.push_back(image);

    color_shading.create(render_target);

I probably won't make any changes to this pr for a little while since I'm now un-blocked. But it may need revisions before merging.